### PR TITLE
feature: 노드 채팅 알림 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,7 @@
   <component name="ProjectRootManager">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
+  <component name="ProjectType">
+    <option name="id" value="jpab" />
+  </component>
 </project>

--- a/config/expoClient.js
+++ b/config/expoClient.js
@@ -1,0 +1,6 @@
+const { Expo } = require('expo-server-sdk');
+
+// Expo 푸시 알림 객체 생성
+const expo = new Expo();
+
+module.exports = { expo };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "dotenv": "^16.4.7",
+        "expo-server-sdk": "^3.14.0",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.12.0",
@@ -404,6 +405,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -442,6 +449,17 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expo-server-sdk": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-3.14.0.tgz",
+      "integrity": "sha512-vuDDhEhO+MoNX0678rhRzwxaK+dqLwDb6Onv2/ANVM4qdU3pNR5rqUmjnfCGt8VBq4UgmbzpMABuc8qxmd6mPA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.0",
+        "promise-limit": "^2.7.0",
+        "promise-retry": "^2.0.1"
       }
     },
     "node_modules/express": {
@@ -1044,6 +1062,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nodemon": {
       "version": "2.0.22",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
@@ -1140,6 +1178,25 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1205,6 +1262,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/safe-buffer": {
@@ -1566,6 +1632,12 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1613,6 +1685,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "dotenv": "^16.4.7",
+    "expo-server-sdk": "^3.14.0",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.12.0",

--- a/repository/ChatroomStudentRepository.js
+++ b/repository/ChatroomStudentRepository.js
@@ -26,6 +26,25 @@ class ChatroomStudentRepository {
     
     await db.execute(query, params);
   }
+
+  /**
+   * 채팅방의 발신자(senderId)를 제외한 수신자(receiverId) 조회
+   * @param {number} roomId
+   * @param {number} senderId
+   * @returns {Promise<number|null>} - 수신자의 studentId 반환 (없으면 null)
+   */
+//   student_id <> ?
+// → student_id가 senderId와 다른 사용자만 선택 (즉, 보낸 사람 제외)
+  async findReceiverId(roomId, senderId) {
+    const query = `
+      SELECT student_id FROM chatroom_student
+      WHERE chatroom_id = ? AND student_id <> ?
+      LIMIT 1
+    `;
+    const [rows] = await db.execute(query, [roomId, senderId]);
+
+    return rows.length > 0 ? rows[0].student_id : null;
+  }
 }
 
 module.exports = new ChatroomStudentRepository();

--- a/repository/NotificationRepository.js
+++ b/repository/NotificationRepository.js
@@ -7,7 +7,7 @@ class NotificationRepository {
      * @returns {Promise<string|null>} - Expo 푸시 토큰 반환 (없으면 null)
      */
     async getExpoTokenByStudentId(studentId) {
-        const query = `SELECT token FROM expo_token WHERE student_id = ? LIMIT 1`;
+        const query = `SELECT token FROM expo_token WHERE student_id = ?`;
         const [rows] = await db.execute(query, [studentId]);
 
         return rows.length > 0 ? rows[0].token : null;

--- a/repository/NotificationRepository.js
+++ b/repository/NotificationRepository.js
@@ -1,0 +1,17 @@
+const db = require('../config/db');
+
+class NotificationRepository {
+    /**
+     * studentId로 ExpoToken 조회
+     * @param {number} studentId
+     * @returns {Promise<string|null>} - Expo 푸시 토큰 반환 (없으면 null)
+     */
+    async getExpoTokenByStudentId(studentId) {
+        const query = `SELECT token FROM expo_token WHERE student_id = ? LIMIT 1`;
+        const [rows] = await db.execute(query, [studentId]);
+
+        return rows.length > 0 ? rows[0].token : null;
+    }
+}
+
+module.exports = new NotificationRepository();

--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -275,7 +275,10 @@ class ChatService {
         to: expoToken,
         title,
         body,
-        data: { chatroomId }
+        data: {
+          chatroomId,
+          type: "CHAT"
+        }
       };
 
       // 6. 알림 전송

--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -5,6 +5,7 @@ const ChatroomStudentRepository = require('../repository/ChatroomStudentReposito
 const S3UploadService = require('../service/S3UploadService');
 const Chat = require('../model/Chat');
 const chatNamespace = require("../socket/socketServer");
+const { expo } = require('../config/expoClient');  // ✅ 이 부분 추가
 
 /**
  * MySQL DATETIME 형식 (YYYY-MM-DD HH:MM:SS) 타임스탬프 생성 함수

--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -2,6 +2,9 @@
 const ChatRepository = require('../repository/ChatRepository');
 const ChatroomRepository = require('../repository/ChatroomRepository');
 const ChatroomStudentRepository = require('../repository/ChatroomStudentRepository');
+const notificationRepository = require('../repository/notificationRepository');
+const studentRepository = require('../repository/StudentRepository');
+const { expo } = require('../config/expoClient');
 
 /**
  * MySQL DATETIME 형식 (YYYY-MM-DD HH:MM:SS) 타임스탬프 생성 함수
@@ -72,14 +75,67 @@ class ChatService {
       if (s && s.studentId && !connectedStudentIds.includes(s.studentId)) {
         console.log(s.studentId);
         connectedStudentIds.push(s.studentId);
+      } else{// 상대방이 채팅방에 없을 경우에 알림을 보낸다.
+        await this.sendPushNotification(socket.studentId, socket.roomId, message.message);
       }
     }
     
     // 7. 채팅방의 읽지 않은 메시지 수 업데이트 (발신자 제외하고, 연결되어 있지 않은 사용자)
     await ChatroomStudentRepository.updateUnreadCount(socket.roomId, socket.studentId, connectedStudentIds);
-    
+
     console.log(`Message broadcasted and saved in room ${socket.roomId}:`, message);
     return message;
+  }
+
+  /**
+   * 푸시 알림 전송
+   * @param {number} senderId - 메시지 발신자 ID
+   * @param {number} chatroomId - 채팅방 ID
+   * @param {string} message - 메시지 내용
+   */
+  async sendPushNotification(senderId, chatroomId, message) {
+    try {
+      // 1. 채팅방에서 수신자(receiverId) 찾기
+      const receiverId = await ChatroomStudentRepository.findReceiverId(chatroomId, senderId);
+      if (!receiverId) {
+        console.warn(`${chatroomId}채팅룸에 참여하고 있는 학생이 없습니다.`);
+        return;
+      }
+
+      // 2. 수신자의 ExpoToken 조회
+      const expoToken = await notificationRepository.getExpoTokenByStudentId(receiverId);
+      if (!expoToken) {
+        console.warn(`${receiverId}의 Expo토큰이 존재하지 않습니다.`);
+        return;
+      }
+
+      // 3. 수신자의 학생 정보 조회
+      const receiver = await studentRepository.getStudentById(receiverId);
+      if (!receiver) {
+        console.warn(`수신자의 학생 정보가 존재하지 않습니다.`);
+        return;
+      }
+
+      // 4. 한국인 여부에 따라 제목 설정
+      const title = receiver.isKorean ? "새로운 메시지가 도착했습니다." : "New Message";
+      const body = `${receiver.name} : ${message}`;
+
+      // 5. Expo Push Notification 메시지 생성
+      const pushMessage = {
+        to: expoToken,
+        title,
+        body,
+        data: { chatroomId }
+      };
+
+      // 6. 알림 전송
+      const response = await expo.sendPushNotificationsAsync([pushMessage]);
+      console.log(`${receiverId}에게 성공적으로 알림을 보냈습니다.`, response);
+
+    } catch (error) {
+      console.error(`알림을 보내는데 실패하였습니다.`, error);
+      // 알림이 실패해도 프로세스를 종료하지 않음
+    }
   }
 }
 

--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -5,7 +5,7 @@ const ChatroomStudentRepository = require('../repository/ChatroomStudentReposito
 const S3UploadService = require('../service/S3UploadService');
 const Chat = require('../model/Chat');
 const chatNamespace = require("../socket/socketServer");
-const { expo } = require('../config/expoClient');  // ✅ 이 부분 추가
+const { expo } = require('../config/expoClient');
 
 /**
  * MySQL DATETIME 형식 (YYYY-MM-DD HH:MM:SS) 타임스탬프 생성 함수


### PR DESCRIPTION
## 📌 관련 이슈
[노드 채팅 알림 구현](https://github.com/buddy-ya/be-node/issues/4)[#4]
<br><br>

## 🛠️ 작업 내용
- 채팅 관련 알림 로직 추가

<br><br>

## 🎯 리뷰 포인트

- 현재 노드에 대한 코드가 다들 이해하기 어려울 거라는 가정하에 주석을 제거하지 않고 pr을 올렸습니다.
- 채팅을 보낼 때 해당 유저가 채팅방을 보고 있지 않을 경우에 알림을 보냈습니다.
- 알림을 보내는데 실패하여도 채팅에 관련 로직은 실패하지 않고, 로그만 남겼습니다.

<br><br>
### 같이 고민해보고 싶은점 🤔 
**DB 쿼리 관련**
- 지금 node에서는 쿼리문을 직접 작성하는데 스프링과 달리 @Transactional이 없어서 만약에 db관련 작업에 실패했을 때
어떻게 동작할 지 예측이 잘 되지 않아, 어떻게 해결해야 될지 같이 고민해봐야할 것 같습니다.
- student를 조회할 때 현재는 모든 컬럼을 다 조회해서 들고 오는데, 필요한 부분만 들고 오는 쿼리/메서드를 repository에
따로 작성하는 것이 좋을지에 대해서 같이 고민해 보고 싶습니다.

<br><br>

## 📎 커밋 범위 링크
<br><br>
