### PR TITLE
feat: 채팅방 뒤로가기 시에 실시간 통신 끊기

### DIFF
--- a/socket/socketServer.js
+++ b/socket/socketServer.js
@@ -65,6 +65,25 @@ chatNamespace.on('connection', (socket) => {
     }
   });
 
+  // 'room_back' 이벤트: 채팅방 UI를 벗어나 뒤로가기 할 때 호출
+  // 클라이언트는 { roomId: <roomId> } 형태의 payload를 전달합니다.
+  socket.on('room_back', (data, callback) => {
+    try {
+      const roomId = parseInt(data.roomId, 10);
+      socket.leave(roomId.toString());
+      console.log(`Student ${socket.studentId} left room ${roomId} using room_back event`);
+      if (callback && typeof callback === 'function') {
+        callback({ status: 'success' });
+      }
+    } catch (err) {
+      console.error("Error processing room_back:", err);
+      if (callback && typeof callback === 'function') {
+        callback({ status: 'error' });
+      }
+    }
+  });
+
+
   // 'room_out' 이벤트 핸들러 (data에 roomId 포함)
   // 클라이언트는 { roomId: <roomId> } 형태의 payload를 전달합니다.
   socket.on('room_out', async (data, callback) => {


### PR DESCRIPTION
## 📌 관련 이슈
[노드 실시간 채팅 구현 #2](https://github.com/buddy-ya/be-node/issues/2)
<br><br>

## 🛠️ 작업 내용
**Socket.IO 실시간 채팅 기능 구현**

- **채팅방 진입/퇴장 이벤트 구현**
  - 채팅방에 진입할 때는 `room_in` 이벤트를 발생시켜, 해당 소켓을 지정된 채팅방에 `join` 시킵니다.
  - 채팅방에서 뒤로가기를 할 경우 `room_back` 이벤트를 전송하여, 해당 소켓을 지정된 채팅방에서 `leave` 시킵니다.
  
- **실시간 통신 상태 관리**
  - `room_back` 이벤트로 소켓을 방에서 제거함으로써, 서버에서는 해당 사용자가 채팅방에 머무르지 않는 상태로 인식하게 됩니다.
  - expo-notification 등 푸시 알림 시스템은 소켓의 join/leave와 별도로 동작하므로, 이 이벤트를 사용해도 알림 기능에는 영향을 주지 않습니다.


##  🎯리뷰 포인트
채팅에서 발생하는 실시간 통신 이벤트는 총 네 개입니다.
- `room_in`: 채팅방 입장
- `room_back`: 채팅방 뒤로가기 (실시간 통신 비활성화)
- `message`: 채팅 메시지 전송 및 처리
- `room_out`: 채팅방 완전 탈퇴