### PR TITLE
feat: 나가지 않은 상대에게만 채팅 알림 전송

### DIFF
--- a/repository/NotificationRepository.js
+++ b/repository/NotificationRepository.js
@@ -1,4 +1,4 @@
-const db = require('../config/db');
+const db = require('../config/dbConfig');
 
 class NotificationRepository {
     /**

--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -60,6 +60,15 @@ class ChatService {
     const notConnectedStudentIds = uniqueAllStudentIds.filter(
       id => id !== socket.studentId && !connectedStudentIds.includes(id)
     );
+
+    // 연결되지 않은 학생들에게 각각 푸시 알림 전송
+    for (const studentId of notConnectedStudentIds) {
+      const student = await ChatroomStudentRepository.findByChatroomAndStudentId(socket.roomId, studentId);
+      if (student && student.exited === 0) {
+        await this.sendPushNotification(studentId, socket.roomId, data.message);
+      }
+    }
+
     console.log('Students not connected in room:', notConnectedStudentIds);
 
     await this.updateUnreadCount(socket, notConnectedStudentIds);
@@ -132,9 +141,7 @@ class ChatService {
       const s = namespace.sockets.get(id);
       if (s && s.studentId && !connectedStudentIds.includes(s.studentId)) {
         connectedStudentIds.push(s.studentId);
-      } else{// 상대방이 채팅방에 없을 경우에 알림을 보낸다.
-        await this.sendPushNotification(socket.studentId, socket.roomId, message.message);
-      }
+      } 
     }
     return connectedStudentIds;
   }
@@ -213,6 +220,14 @@ class ChatService {
     const notConnectedStudentIds = uniqueAllStudentIds.filter(
       id => id !== userInfo.studentId && !connectedStudentIds.includes(id)
     );
+
+    for (const studentId of notConnectedStudentIds) {
+      const student = await ChatroomStudentRepository.findByChatroomAndStudentId(socket.roomId, studentId);
+      if (student && student.exited === 0) {
+        await this.sendPushNotification(studentId, socket.roomId, data.message);
+      }
+    }
+
     console.log('Students not connected in room:', notConnectedStudentIds);
     await this.updateUnreadCount({ roomId: roomId, studentId: userInfo.studentId }, notConnectedStudentIds);
 

--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -67,7 +67,7 @@ class ChatService {
     for (const studentId of notConnectedStudentIds) {
       const student = await ChatroomStudentRepository.findByChatroomAndStudentId(socket.roomId, studentId);
       if (student && student.exited === false) {
-        await this.sendPushNotification(studentId, socket.roomId, data.message);
+        await this.sendPushNotification(studentId, socket.roomId, 'text', data.message);
       }
     }
 
@@ -224,9 +224,9 @@ class ChatService {
     );
 
     for (const studentId of notConnectedStudentIds) {
-      const student = await ChatroomStudentRepository.findByChatroomAndStudentId(socket.roomId, studentId);
+      const student = await ChatroomStudentRepository.findByChatroomAndStudentId(roomId, studentId);
       if (student && student.exited === false) {
-        await this.sendPushNotification(studentId, socket.roomId, data.message);
+        await this.sendPushNotification(studentId, roomId, 'image', chat.message);
       }
     }
 

--- a/socket/socketServer.js
+++ b/socket/socketServer.js
@@ -16,7 +16,7 @@ const ChatService = require('../service/ChatService');
 
 // 네임스페이스를 정적으로 설정 (쿼리 파라미터 없이 단순 URL 사용)
 // 클라이언트는 "ws://localhost:3000/ws/chat" 형식으로 연결합니다.
-const chatNamespace = io.of('node/ws/chat');
+const chatNamespace = io.of('/chat');
 
 // 네임스페이스에 인증 미들웨어 적용
 chatNamespace.use((socket, next) => {


### PR DESCRIPTION
## 📌 관련 이슈
[노드 실시간 채팅 구현 #2](https://github.com/buddy-ya/be-node/issues/2)
<br><br>

## 🛠️ 작업 내용
**Socket.IO 실시간 채팅 기능 구현**

- **채팅 알림 전송 관련 정책**
  - `room_back` 이벤트로 소켓을 방에서 제거한 사용자들은 실시간 통신을 받을 수없는 상태이므로, 알림을 받아야 합니다.
  -  실시간 통신을 받을 수 있는 사용자들, 즉 채팅방 안에 진입해있는 유저들은 채팅 알림을 받을 필요가 없습니다.
  -  다만, 채팅방을 나간 유저들에게는 알림이 전송되어서는 안됩니다. 따라서 `exited` 필드를 이용하여 채팅방을 나가지 않은 유저들에게만 알림을 전송했습니다.

- **채팅 알림 전송 관련 컴파일 에러**
  -  의존성 및 잘못 코드가 적혀있는 부분들을 수정하여 고쳤습니다.
