### PR TITLE
fix: chat 고유 id 생성 이후 브로드캐스트

### DIFF
--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -46,8 +46,9 @@ class ChatService {
     const timestamp = getFormattedTimestamp();
     const chat = this.buildChat(socket, data, timestamp);
 
-    this.broadcastChat(socket, chat, timestamp);
     await this.saveChat(chat);
+
+    this.broadcastChat(socket, chat, timestamp);
 
     await this.updateChatroomLastMessage(socket, chat, timestamp);
 
@@ -106,6 +107,7 @@ class ChatService {
    */
   broadcastChat(socket, chat, timestamp) {
     socket.to(socket.roomId.toString()).emit('message', {
+      id: chat.id,
       type: chat.type,
       roomId: socket.roomId,
       senderId: socket.studentId,


### PR DESCRIPTION
## 📌 관련 이슈
[노드 실시간 채팅 구현 #2](https://github.com/buddy-ya/be-node/issues/2)
<br><br>

## 🛠️ 작업 내용
- **채팅 송신자 제외 브로드 캐스트**
  -  `Chat` 고유 id를 생성 이후에 페이로드에 담아 브로드캐스트 하도록 수정했습니다.
