### PR TITLE
fix: 채팅 전송 시 알림 body에 이름 오류 수정

### DIFF
--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -228,7 +228,7 @@ class ChatService {
     for (const studentId of notConnectedStudentIds) {
       const student = await ChatroomStudentRepository.findByChatroomAndStudentId(roomId, studentId);
       if (student && student.exited === false) {
-        await this.sendPushNotification(socket.studentId, studentId, roomId, 'image', chat.message);
+        await this.sendPushNotification(userInfo.studentId, studentId, roomId, 'image', chat.message);
       }
     }
 

--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -272,8 +272,8 @@ class ChatService {
         console.warn(`수신자의 학생 정보가 존재하지 않습니다.`);
         return;
       }
-      // 2. 수신자의 ExpoToken 조회
 
+      // 2. 수신자의 ExpoToken 조회
       const expoToken = await NotificationRepository.getExpoTokenByStudentId(receiverId);
       if (!expoToken) {
         console.warn(`${receiverId}의 Expo토큰이 존재하지 않습니다.`);


### PR DESCRIPTION
## 📌 관련 이슈
[채팅 전송 시 알림 body에 이름 오류](https://github.com/buddy-ya/be-node/issues/14)[#14]

<br><br>

## 🛠️ 작업 내용
- 알림 전송 메서드 호출시 전송자의 아이디를 추가하여 호출하여
알림 전송 시 수신자가 송신자의 닉네임을 볼 수 있도록 수정

<br><br>

## 🎯 리뷰 포인트
- 컨벤션에 어긋난 부분은 없나요?

<br><br>

## 📎 커밋 범위 링크

<br><br>
