### PR TITLE
fix: 채팅 전송 시 알림 body에 이름 오류 재반영

### DIFF
--- a/service/ChatService.js
+++ b/service/ChatService.js
@@ -68,7 +68,7 @@ class ChatService {
     for (const studentId of notConnectedStudentIds) {
       const student = await ChatroomStudentRepository.findByChatroomAndStudentId(socket.roomId, studentId);
       if (student && student.exited === false) {
-        await this.sendPushNotification(studentId, socket.roomId, 'text', data.message);
+        await this.sendPushNotification(socket.studentId, studentId, socket.roomId, 'text', data.message);
       }
     }
 
@@ -232,7 +232,7 @@ class ChatService {
     for (const studentId of notConnectedStudentIds) {
       const student = await ChatroomStudentRepository.findByChatroomAndStudentId(roomId, studentId);
       if (student && student.exited === false) {
-        await this.sendPushNotification(studentId, roomId, 'image', chat.message);
+        await this.sendPushNotification(userInfo.studentId, studentId, roomId, 'image', chat.message);
       }
     }
 
@@ -262,12 +262,13 @@ class ChatService {
 
   /**
    * 푸시 알림 전송
-   * @param receiverId
+   * @param {number} senderId - 메시지 보낸 사람 ID
+   * @param {number} receiverId - 메시지 받는 사람 ID
    * @param {number} chatroomId - 채팅방 ID
    * @param {string} type - 메시지 type (예: "text", "image")
-   * @param {string} message - 메시지 내용 (text인 경우)
+   * @param {string} message - 메시지 내용 (text일 경우)
    */
-  async sendPushNotification(receiverId, chatroomId, type, message) {
+  async sendPushNotification(senderId, receiverId, chatroomId, type, message) {
     try {
       // 1. 수신자의 학생 정보 조회
       const receiver = await StudentRepository.getStudentById(receiverId);
@@ -287,9 +288,10 @@ class ChatService {
       const title = receiver.korean ? "새로운 메시지가 도착했습니다." : "New Message";
 
       // 4. 메시지 타입에 따라 body 설정
+      const sender = await StudentRepository.getStudentById(senderId);
       let body;
       if (type === "text") {
-        body = `${receiver.name} : ${message}`;
+        body = `${sender.name} : ${message}`;
       }
       if (type === "image") {
         body = receiver.korean ? "사진을 보냈습니다." : "Sent an image.";


### PR DESCRIPTION
## 📌 관련 이슈
[채팅 전송 시 알림 body에 이름 오류 재반영](https://github.com/buddy-ya/be-node/issues/20)[#20]

<br><br>

## 🛠️ 작업 내용
- 알림 전송 메서드 호출시 전송자의 아이디를 추가하여 호출하여
알림 전송 시 수신자가 송신자의 닉네임을 볼 수 있도록 수정

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
